### PR TITLE
set plan order to ascending

### DIFF
--- a/src/pages/auth/accounts/Plans/index.js
+++ b/src/pages/auth/accounts/Plans/index.js
@@ -78,7 +78,8 @@ const Plans = () => {
                 });
             });
             if(p.length > 0){
-                setPlans(p);
+                const ascendingOrderPlans = p.sort((a, b) => parseFloat(a.price) - parseFloat(b.price));
+                setPlans(ascendingOrderPlans);
             }
             setLoading(false);
         });


### PR DESCRIPTION
Hi, 

It looks like the plans are displayed in no particular order. I think it would make more sense to display then in an ascending order by price :) 


